### PR TITLE
Fix worfklow issue running terraform apply on empty dir

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -13,7 +13,9 @@ permissions:
 
 jobs:
   terraform:
-    if: github.repository != 'hashicorp-education/learn-terraform-github-actions'
+    defaults:
+      run:
+        working-directory: ${{ env.TF_ACTIONS_WORKING_DIR }}
     name: "Terraform Apply"
     runs-on: ubuntu-latest
     permissions: # granular permissions


### PR DESCRIPTION
This adds a fix so that the working directory is ./stack