### PR TITLE
Specify the AppSpec in the pipeline deployment configuration

### DIFF
--- a/stack/pipeline.tf
+++ b/stack/pipeline.tf
@@ -143,6 +143,25 @@ resource "aws_codepipeline" "fryrank_lambda_pipeline" {
         configuration = {
           ApplicationName = aws_codedeploy_app.lambda_codedeploy_app.name
           DeploymentGroupName = aws_codedeploy_deployment_group.lambda_deployment_groups[action.key].deployment_group_name
+          Revision = jsonencode({
+            RevisionType = "AppSpecContent"
+            AppSpecContent = {
+              Content = jsonencode({
+                version = "0.0"
+                Resources = [{
+                  (action.value.name) = {
+                    Type = "AWS::Lambda::Function"
+                    Properties = {
+                      Name = action.value.name
+                      Alias = "Production"
+                      CurrentVersion = "$LATEST"
+                      TargetVersion = "$LATEST"
+                    }
+                  }
+                }]
+              })
+            }
+          })
         }
       }
     }


### PR DESCRIPTION
Directly specify the AppSpec in the pipeline deployment configuration rather than generating the appspec files at build time

It passes terraform validate.

Terraform Plan shows:

```
~ action {
              ~ configuration      = {
                  + "Revision"            = jsonencode(
                        {
                          + AppSpecContent = {
                              + Content = jsonencode(
                                    {
                                      + Resources = [
                                          + {
                                              + upsertPublicUserMetadata = {
                                                  + Properties = {
                                                      + Alias          = "Production"
                                                      + CurrentVersion = "$LATEST"
                                                      + Name           = "upsertPublicUserMetadata"
                                                      + TargetVersion  = "$LATEST"
                                                    }
                                                  + Type       = "AWS::Lambda::Function"
                                                }
                                            },
                                        ]
                                      + version   = "0.0"
                                    }
                                )
                            }
                          + RevisionType   = "AppSpecContent"
                        }
                    )
                    # (2 unchanged elements hidden)
                }
                name               = "Deploy-upsertPublicUserMetadata"
                # (11 unchanged attributes hidden)
            }
        }
```
