### PR TITLE
Create one deployment group for all Lambda functions

### DIFF
--- a/stack/codedeploy.tf
+++ b/stack/codedeploy.tf
@@ -50,11 +50,9 @@ resource "aws_iam_role_policy" "codedeploy_s3_policy" {
 }
 
 # Create deployment groups for each Lambda function
-resource "aws_codedeploy_deployment_group" "lambda_deployment_groups" {
-  for_each = local.lambda_functions
-
+resource "aws_codedeploy_deployment_group" "lambda_deployment_group" {
   app_name               = aws_codedeploy_app.lambda_codedeploy_app.name
-  deployment_group_name  = each.value.name
+  deployment_group_name  = "${local.name}-lambda-deployment-group"
   deployment_config_name = "CodeDeployDefault.LambdaAllAtOnce"
   service_role_arn      = aws_iam_role.codedeploy_service_role.arn
 

--- a/stack/pipeline.tf
+++ b/stack/pipeline.tf
@@ -130,20 +130,17 @@ resource "aws_codepipeline" "fryrank_lambda_pipeline" {
   stage {
     name = "Deploy"
 
-    dynamic "action" {
-      for_each = local.lambda_functions
-      content {
-        name            = "Deploy-${action.value.name}"
-        category        = "Deploy"
-        owner          = "AWS"
-        provider       = "CodeDeploy"
-        input_artifacts = ["build_output"]
-        version        = "1"
+    action {
+      name            = "Deploy"
+      category        = "Deploy"
+      owner          = "AWS"
+      provider       = "CodeDeploy"
+      input_artifacts = ["build_output"]
+      version        = "1"
 
-        configuration = {
-          ApplicationName = aws_codedeploy_app.lambda_codedeploy_app.name
-          DeploymentGroupName = aws_codedeploy_deployment_group.lambda_deployment_groups[action.key].deployment_group_name
-        }
+      configuration = {
+        ApplicationName = aws_codedeploy_app.lambda_codedeploy_app.name
+        DeploymentGroupName = aws_codedeploy_deployment_group.lambda_deployment_group.deployment_group_name
       }
     }
   }


### PR DESCRIPTION
Puts all Lambdas in one deployment group, which will then read the appspec file and deploy the Lambdas based off of that.