### PR TITLE
Update the frontend S3 policy to allow both Cloudfront OAI and OAC access

### DIFF
--- a/stack/frontend-s3.tf
+++ b/stack/frontend-s3.tf
@@ -129,21 +129,30 @@ resource "aws_s3_bucket_website_configuration" "spa_bucket" {
 resource "aws_s3_bucket_policy" "spa_bucket_policy" {
   bucket = aws_s3_bucket.spa_bucket.id
   policy = jsonencode({
-    Version = "2012-10-17"
+    Version = "2012-10-17",
     Statement = [
       {
-        Sid       = "AllowCloudFrontServicePrincipal"
-        Effect    = "Allow"
+        Sid = "AllowCloudFrontServicePrincipalReadOnly",
+        Effect = "Allow",
         Principal = {
           Service = "cloudfront.amazonaws.com"
-        }
-        Action   = "s3:GetObject"
-        Resource = "${aws_s3_bucket.spa_bucket.arn}/*"
+        },
+        Action = "s3:GetObject",
+        Resource = "${aws_s3_bucket.spa_bucket.arn}/*",
         Condition = {
           StringEquals = {
             "AWS:SourceArn" = aws_cloudfront_distribution.spa_distribution.arn
           }
         }
+      },
+      {
+        Sid = "AllowLegacyOAIReadOnly",
+        Effect = "Allow",
+        Principal = {
+          AWS = "arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ${aws_cloudfront_origin_access_identity.spa_oai.id}"
+        },
+        Action = "s3:GetObject",
+        Resource = "${aws_s3_bucket.spa_bucket.arn}/*"
       }
     ]
   })


### PR DESCRIPTION
This creates permission for both OAC and OAI to read from the S3 bucket, without modifying the CloudFront distribution yet. This is a recommended step in the docs here: https://aws.amazon.com/blogs/networking-and-content-delivery/amazon-cloudfront-introduces-origin-access-control-oac/