### PR TITLE
Establish API Gateway REST API quotas and throttling for a low-traffic web application

### DIFF
--- a/stack/api-gateway.tf
+++ b/stack/api-gateway.tf
@@ -25,3 +25,23 @@ resource "aws_api_gateway_stage" "fryrank_api" {
   rest_api_id   = aws_api_gateway_rest_api.fryrank_api.id
   stage_name    = "beta"
 }
+
+resource "aws_api_gateway_usage_plan" "fryrank_api_usage_plan" {
+  name          = "fryrank-api-usage-plan"
+  description   = "quota and throtte settings for fryrank_api"
+
+  api_stages {
+    api_id = aws_api_gateway_rest_api.fryrank_api.id
+    stage = aws_api_gateway_stage.fryrank_api.stage_name
+  }
+
+  quota_settings {
+    limit = 50000
+    period = "MONTH"
+  }
+
+  throttle_settings {
+    burst_limit = 500
+    rate_limit  = 100.0
+  }
+}

--- a/stack/api-gateway.tf
+++ b/stack/api-gateway.tf
@@ -36,12 +36,12 @@ resource "aws_api_gateway_usage_plan" "fryrank_api_usage_plan" {
   }
 
   quota_settings {
-    limit = 50000
-    period = "MONTH"
+    limit = 5000
+    period = "DAY"
   }
 
   throttle_settings {
-    burst_limit = 500
-    rate_limit  = 100.0
+    burst_limit = 100
+    rate_limit  = 50.0
   }
 }


### PR DESCRIPTION
Setting invocation quota and throttling on the API Gateway to prevent abuse (and unexpected billing costs)

- Daily quota of 5,000 API Gateway invocations -- this would total about 150,000 requests a month, still well under the 1 million invocation limit for the free tier for both APIG and Lambda (setting a monthly limit instead of a daily limit also works, but the benefit of a daily limit is that the API can reset and become available the next day in case the quota is reached the day prior, instead of being entirely unavailable for the rest of the month)
- Rate limit to 50 requests per second, set burst limit to 100 requests, in case of sporadic spikes in traffic

Resolves https://github.com/FryRankApp/FryRankInfra/issues/63