### PR TITLE
Hardcode 'live' in Open API spec to point correctly to the 'live' alias

### DIFF
--- a/stack/api-gateway.tf
+++ b/stack/api-gateway.tf
@@ -24,6 +24,11 @@ resource "aws_api_gateway_stage" "fryrank_api_v1" {
   deployment_id = aws_api_gateway_deployment.fryrank_api.id
   rest_api_id   = aws_api_gateway_rest_api.fryrank_api.id
   stage_name    = "v1"
+
+  variables = {
+    lambdaAlias = "live"
+  }
+
 }
 
 resource "aws_api_gateway_usage_plan" "fryrank_api_usage_plan" {

--- a/stack/api-gateway.tf
+++ b/stack/api-gateway.tf
@@ -26,7 +26,7 @@ resource "aws_api_gateway_stage" "fryrank_api_v1" {
   stage_name    = "v1"
 
   variables = {
-    lambdaAlias = "live"
+    lambdaAlias = local.lambda_alias_name
   }
 
 }

--- a/stack/api-gateway.tf
+++ b/stack/api-gateway.tf
@@ -24,11 +24,6 @@ resource "aws_api_gateway_stage" "fryrank_api_v1" {
   deployment_id = aws_api_gateway_deployment.fryrank_api.id
   rest_api_id   = aws_api_gateway_rest_api.fryrank_api.id
   stage_name    = "v1"
-
-  variables = {
-    lambdaAlias = local.lambda_alias_name
-  }
-
 }
 
 resource "aws_api_gateway_usage_plan" "fryrank_api_usage_plan" {

--- a/stack/fryrank-openapi-spec.json
+++ b/stack/fryrank-openapi-spec.json
@@ -115,7 +115,7 @@
           "httpMethod": "POST",
           "payloadFormatVersion": "1.0",
           "type": "AWS_PROXY",
-          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:getPublicUserMetadata/invocations"
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:getPublicUserMetadata:${stageVariables.lambdaAlias}/invocations"
         }
       },
       "put": {
@@ -183,7 +183,7 @@
           "httpMethod": "POST",
           "payloadFormatVersion": "1.0",
           "type": "AWS_PROXY",
-          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:putPublicUserMetadata/invocations"
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:putPublicUserMetadata:${stageVariables.lambdaAlias}/invocations"
         }
       },
       "post": {
@@ -243,7 +243,7 @@
           "httpMethod": "POST",
           "payloadFormatVersion": "1.0",
           "type": "AWS_PROXY",
-          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:upsertPublicUserMetadata/invocations"
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:upsertPublicUserMetadata:${stageVariables.lambdaAlias}/invocations"
         }
       }
     },
@@ -359,7 +359,7 @@
           "httpMethod": "POST",
           "payloadFormatVersion": "1.0",
           "type": "AWS_PROXY",
-          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:getAllReviews/invocations"
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:getAllReviews:${stageVariables.lambdaAlias}/invocations"
         }
       },
       "post": {
@@ -419,7 +419,7 @@
           "httpMethod": "POST",
           "payloadFormatVersion": "1.0",
           "type": "AWS_PROXY",
-          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:addNewReview/invocations"
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:addNewReview:${stageVariables.lambdaAlias}/invocations"
         }
       },
       "delete": {
@@ -472,7 +472,7 @@
           "httpMethod": "POST",
           "payloadFormatVersion": "1.0",
           "type": "AWS_PROXY",
-          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:deleteReview/invocations"
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:deleteReview:${stageVariables.lambdaAlias}/invocations"
         }
       }
     },
@@ -581,7 +581,7 @@
           "httpMethod": "POST",
           "payloadFormatVersion": "1.0",
           "type": "AWS_PROXY",
-          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:getRecentReviews/invocations"
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:getRecentReviews:${stageVariables.lambdaAlias}/invocations"
         }
       }
     },
@@ -698,7 +698,7 @@
           "httpMethod": "POST",
           "payloadFormatVersion": "1.0",
           "type": "AWS_PROXY",
-          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:getAggregateReviewInformation/invocations"
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:getAggregateReviewInformation:${stageVariables.lambdaAlias}/invocations"
         }
       }
     }

--- a/stack/fryrank-openapi-spec.json
+++ b/stack/fryrank-openapi-spec.json
@@ -115,7 +115,7 @@
           "httpMethod": "POST",
           "payloadFormatVersion": "1.0",
           "type": "AWS_PROXY",
-          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:getPublicUserMetadata:${stageVariables.lambdaAlias}/invocations"
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:getPublicUserMetadata:live/invocations"
         }
       },
       "put": {
@@ -183,7 +183,7 @@
           "httpMethod": "POST",
           "payloadFormatVersion": "1.0",
           "type": "AWS_PROXY",
-          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:putPublicUserMetadata:${stageVariables.lambdaAlias}/invocations"
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:putPublicUserMetadata:live/invocations"
         }
       },
       "post": {
@@ -243,7 +243,7 @@
           "httpMethod": "POST",
           "payloadFormatVersion": "1.0",
           "type": "AWS_PROXY",
-          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:upsertPublicUserMetadata:${stageVariables.lambdaAlias}/invocations"
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:upsertPublicUserMetadata:live/invocations"
         }
       }
     },
@@ -359,7 +359,7 @@
           "httpMethod": "POST",
           "payloadFormatVersion": "1.0",
           "type": "AWS_PROXY",
-          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:getAllReviews:${stageVariables.lambdaAlias}/invocations"
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:getAllReviews:live/invocations"
         }
       },
       "post": {
@@ -419,7 +419,7 @@
           "httpMethod": "POST",
           "payloadFormatVersion": "1.0",
           "type": "AWS_PROXY",
-          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:addNewReview:${stageVariables.lambdaAlias}/invocations"
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:addNewReview:live/invocations"
         }
       },
       "delete": {
@@ -472,7 +472,7 @@
           "httpMethod": "POST",
           "payloadFormatVersion": "1.0",
           "type": "AWS_PROXY",
-          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:deleteReview:${stageVariables.lambdaAlias}/invocations"
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:deleteReview:live/invocations"
         }
       }
     },
@@ -581,7 +581,7 @@
           "httpMethod": "POST",
           "payloadFormatVersion": "1.0",
           "type": "AWS_PROXY",
-          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:getRecentReviews:${stageVariables.lambdaAlias}/invocations"
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:getRecentReviews:live/invocations"
         }
       }
     },
@@ -698,7 +698,7 @@
           "httpMethod": "POST",
           "payloadFormatVersion": "1.0",
           "type": "AWS_PROXY",
-          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:getAggregateReviewInformation:${stageVariables.lambdaAlias}/invocations"
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:390844755099:function:getAggregateReviewInformation:live/invocations"
         }
       }
     }

--- a/stack/lambda.tf
+++ b/stack/lambda.tf
@@ -131,6 +131,7 @@ resource "aws_lambda_permission" "fryrank_api_lambda_permission" {
   for_each      = local.create_lambdas_flag ? local.lambda_functions : {}
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.fryrank_api_lambdas[each.key].function_name
+  qualifier     = "live"
   principal     = "apigateway.amazonaws.com"
 
   # The /* part allows invocation from any stage, method and resource path

--- a/stack/lambda.tf
+++ b/stack/lambda.tf
@@ -5,7 +5,6 @@ variable "create_lambdas" {
 }
 
 locals {
-  lambda_alias_name = "live"
   # If the top-level variable `create_lambdas` is defined elsewhere this will
   # use that value. If it's not defined, default to false to avoid trying to
   # create Lambda functions when the S3 object isn't present.
@@ -132,7 +131,7 @@ resource "aws_lambda_permission" "fryrank_api_lambda_permission" {
   for_each      = local.create_lambdas_flag ? local.lambda_functions : {}
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.fryrank_api_lambdas[each.key].function_name
-  qualifier     = local.lambda_alias_name
+  qualifier     = "live"
   principal     = "apigateway.amazonaws.com"
 
   # The /* part allows invocation from any stage, method and resource path

--- a/stack/lambda.tf
+++ b/stack/lambda.tf
@@ -5,6 +5,7 @@ variable "create_lambdas" {
 }
 
 locals {
+  lambda_alias_name = "live"
   # If the top-level variable `create_lambdas` is defined elsewhere this will
   # use that value. If it's not defined, default to false to avoid trying to
   # create Lambda functions when the S3 object isn't present.
@@ -131,7 +132,7 @@ resource "aws_lambda_permission" "fryrank_api_lambda_permission" {
   for_each      = local.create_lambdas_flag ? local.lambda_functions : {}
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.fryrank_api_lambdas[each.key].function_name
-  qualifier     = "live"
+  qualifier     = local.lambda_alias_name
   principal     = "apigateway.amazonaws.com"
 
   # The /* part allows invocation from any stage, method and resource path


### PR DESCRIPTION
In the Open API spec, route the API Gateway directly to the 'live' alias, because the `stageName.lambdaAlias` does not resolve.

Verified in the AWS console that the API Gateway integration request points to the 'live' alias.