### PR TITLE
Increasing timeout and memory to reduce likelihood of a timeout

### DIFF
--- a/stack/api-gateway.tf
+++ b/stack/api-gateway.tf
@@ -25,10 +25,6 @@ resource "aws_api_gateway_stage" "fryrank_api_v1" {
   rest_api_id   = aws_api_gateway_rest_api.fryrank_api.id
   stage_name    = "v1"
 
-  variables = {
-    lambdaAlias = local.lambda_alias_name
-  }
-
 }
 
 resource "aws_api_gateway_usage_plan" "fryrank_api_usage_plan" {

--- a/stack/lambda.tf
+++ b/stack/lambda.tf
@@ -5,7 +5,6 @@ variable "create_lambdas" {
 }
 
 locals {
-  lambda_alias_name = "live"
   # If the top-level variable `create_lambdas` is defined elsewhere this will
   # use that value. If it's not defined, default to false to avoid trying to
   # create Lambda functions when the S3 object isn't present.
@@ -163,7 +162,8 @@ resource "aws_lambda_function" "fryrank_api_lambdas" {
 
   runtime     = "java21"
   description = ""
-  timeout     = 15
+  timeout     = 29
+  memory_size = 1024
 
   tracing_config {
     mode = "Active"


### PR DESCRIPTION
- Increasing memory to 1024 MB (1 GB). This can let the function run up to 8x faster (according to Gemini)
- Increasing timeout to 29 seconds. this fits right under API Gateway's default 30s timeout for synchronous API requests

Tested on sandbox at https://d959r0c83rbxj.cloudfront.net/recent-reviews with no errors. Performance difference still in review.