### PR TITLE
Allowing Terraform to update new versions of the Lambda functions so that traffic hits the latest configuration

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -45,6 +45,10 @@ jobs:
       - name: "Terraform Init"
         run: "terraform init -backend-config=backend.hcl"
 
+      - name: "Import existing Lambda live aliases"
+        run: |
+          python3 scripts/import_lambda_aliases.py
+
       - name: "Discover CloudFront Web ACL (beta)"
         run: |
           set -euo pipefail
@@ -120,6 +124,10 @@ jobs:
 
       - name: "Terraform Init"
         run: "terraform init -backend-config=backend.hcl"
+
+      - name: "Import existing Lambda live aliases"
+        run: |
+          python3 scripts/import_lambda_aliases.py
 
       - name: "Discover CloudFront Web ACL (prod)"
         run: |

--- a/deploy.bat
+++ b/deploy.bat
@@ -90,6 +90,15 @@ set "TF_VAR_cloudfront_web_acl_arn=%WEB_ACL_ARN%"
 
 echo TF_VAR_cloudfront_web_acl_arn=%WEB_ACL_ARN%
 
+if /i "%TF_ACTION%"=="apply" (
+    if exist ".terraform" (
+        if exist "scripts\\import_lambda_aliases.py" (
+            echo Importing existing Lambda live aliases if needed...
+            python scripts\\import_lambda_aliases.py
+        )
+    )
+)
+
 echo Running terraform %TF_ACTION% %TF_EXTRA_ARGS%...
 terraform %TF_ACTION% %TF_EXTRA_ARGS%
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -90,5 +90,19 @@ export TF_VAR_cloudfront_web_acl_arn="${WEB_ACL_ARN}"
 
 echo "TF_VAR_cloudfront_web_acl_arn=${WEB_ACL_ARN}"
 
+if [[ "${ACTION}" == "apply" ]]; then
+    # If the "live" Lambda aliases already exist (common in shared environments),
+    # Terraform needs them in state before it can update them to point at newly
+    # published versions.
+    if [[ -d .terraform ]] && [[ -f scripts/import_lambda_aliases.py ]]; then
+        echo "Importing existing Lambda live aliases (if needed)..."
+        if command -v python3 >/dev/null 2>&1; then
+            python3 scripts/import_lambda_aliases.py
+        else
+            python scripts/import_lambda_aliases.py
+        fi
+    fi
+fi
+
 echo "Running terraform ${ACTION}..."
 terraform "${ACTION}" "${TERRAFORM_ARGS[@]}"

--- a/stack/lambda.tf
+++ b/stack/lambda.tf
@@ -131,7 +131,7 @@ resource "aws_lambda_permission" "fryrank_api_lambda_permission" {
   for_each      = local.create_lambdas_flag ? local.lambda_functions : {}
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.fryrank_api_lambdas[each.key].function_name
-  qualifier     = "live"
+  qualifier     = aws_lambda_alias.fryrank_api_lambdas_live[each.key].name
   principal     = "apigateway.amazonaws.com"
 
   # The /* part allows invocation from any stage, method and resource path
@@ -139,7 +139,7 @@ resource "aws_lambda_permission" "fryrank_api_lambda_permission" {
   source_arn = "${aws_api_gateway_rest_api.fryrank_api.execution_arn}/*"
 
   # Explicitly depend on the Lambda function being created first
-  depends_on = [aws_lambda_function.fryrank_api_lambdas]
+  depends_on = [aws_lambda_alias.fryrank_api_lambdas_live]
 }
 
 
@@ -162,6 +162,7 @@ resource "aws_lambda_function" "fryrank_api_lambdas" {
 
   runtime     = "java21"
   description = ""
+  publish     = true
   timeout     = 29
   memory_size = 1024
 
@@ -181,4 +182,11 @@ resource "aws_lambda_function" "fryrank_api_lambdas" {
       "SSM_DISABLE_AUTH_PARAMETER_KEY"     = "DISABLE_AUTH"
     }
   }
+}
+
+resource "aws_lambda_alias" "fryrank_api_lambdas_live" {
+  for_each         = aws_lambda_function.fryrank_api_lambdas
+  name             = "live"
+  function_name    = each.value.function_name
+  function_version = each.value.version
 }

--- a/stack/scripts/import_lambda_aliases.py
+++ b/stack/scripts/import_lambda_aliases.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+LAMBDA_ALIAS_NAME = "live"
+TERRAFORM_ALIAS_RESOURCE_NAME = "fryrank_api_lambdas_live"
+
+# for_each keys in stack/lambda.tf -> actual Lambda function names in AWS
+FUNCTIONS: list[tuple[str, str]] = [
+    ("get_all_reviews", "getAllReviews"),
+    ("add_new_review", "addNewReview"),
+    ("delete_review", "deleteReview"),
+    ("get_aggregate_review_information", "getAggregateReviewInformation"),
+    ("get_top_reviews", "getRecentReviews"),
+    ("get_public_user_metadata", "getPublicUserMetadata"),
+    ("put_public_user_metadata", "putPublicUserMetadata"),
+    ("upsert_public_user_metadata", "upsertPublicUserMetadata"),
+]
+
+
+def _run(cmd: list[str], *, check: bool = False) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        text=True,
+        capture_output=True,
+        check=check,
+    )
+
+
+def _has_alias_resource_config(repo_stack_dir: Path) -> bool:
+    # Import requires the resource to exist in config; avoid noisy failures.
+    needle = f'resource "aws_lambda_alias" "{TERRAFORM_ALIAS_RESOURCE_NAME}"'
+    for tf_file in repo_stack_dir.rglob("*.tf"):
+        try:
+            if needle in tf_file.read_text(encoding="utf-8", errors="ignore"):
+                return True
+        except OSError:
+            continue
+    return False
+
+
+def _terraform_state_has(addr: str) -> bool:
+    cp = _run(["terraform", "state", "show", addr])
+    return cp.returncode == 0
+
+
+def _aws_alias_exists(function_name: str, alias_name: str) -> bool:
+    cp = _run(["aws", "lambda", "get-alias", "--function-name", function_name, "--name", alias_name])
+    return cp.returncode == 0
+
+
+def _terraform_import(addr: str, import_id: str) -> None:
+    cp = _run(["terraform", "import", addr, import_id])
+    if cp.returncode != 0:
+        sys.stderr.write(cp.stdout)
+        sys.stderr.write(cp.stderr)
+        raise SystemExit(cp.returncode)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Idempotently import existing Lambda aliases into Terraform state (for CI/CD + local applies)."
+    )
+    parser.add_argument(
+        "--stack-dir",
+        default=".",
+        help="Path to the Terraform stack working directory (default: current directory).",
+    )
+    args = parser.parse_args()
+
+    stack_dir = Path(args.stack_dir).resolve()
+    os.chdir(stack_dir)
+
+    if not _has_alias_resource_config(stack_dir):
+        print("No aws_lambda_alias resource in config; skipping alias import.")
+        return 0
+
+    imported = 0
+    skipped_in_state = 0
+    skipped_missing_in_aws = 0
+
+    for tf_key, fn_name in FUNCTIONS:
+        addr = f'aws_lambda_alias.{TERRAFORM_ALIAS_RESOURCE_NAME}["{tf_key}"]'
+        if _terraform_state_has(addr):
+            skipped_in_state += 1
+            continue
+
+        if not _aws_alias_exists(fn_name, LAMBDA_ALIAS_NAME):
+            skipped_missing_in_aws += 1
+            continue
+
+        print(f'Importing {addr} <- {fn_name}/{LAMBDA_ALIAS_NAME}')
+        _terraform_import(addr, f"{fn_name}/{LAMBDA_ALIAS_NAME}")
+        imported += 1
+
+    print(
+        "Alias import summary: "
+        f"imported={imported}, "
+        f"already_in_state={skipped_in_state}, "
+        f"missing_in_aws={skipped_missing_in_aws}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/stack/scripts/import_lambda_aliases.py
+++ b/stack/scripts/import_lambda_aliases.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -10,18 +11,6 @@ from pathlib import Path
 
 LAMBDA_ALIAS_NAME = "live"
 TERRAFORM_ALIAS_RESOURCE_NAME = "fryrank_api_lambdas_live"
-
-# for_each keys in stack/lambda.tf -> actual Lambda function names in AWS
-FUNCTIONS: list[tuple[str, str]] = [
-    ("get_all_reviews", "getAllReviews"),
-    ("add_new_review", "addNewReview"),
-    ("delete_review", "deleteReview"),
-    ("get_aggregate_review_information", "getAggregateReviewInformation"),
-    ("get_top_reviews", "getRecentReviews"),
-    ("get_public_user_metadata", "getPublicUserMetadata"),
-    ("put_public_user_metadata", "putPublicUserMetadata"),
-    ("upsert_public_user_metadata", "upsertPublicUserMetadata"),
-]
 
 
 def _run(cmd: list[str], *, check: bool = False) -> subprocess.CompletedProcess[str]:
@@ -45,9 +34,92 @@ def _has_alias_resource_config(repo_stack_dir: Path) -> bool:
     return False
 
 
+def _extract_brace_block(text: str, open_brace_index: int) -> str | None:
+    depth = 0
+    for i in range(open_brace_index, len(text)):
+        ch = text[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[open_brace_index : i + 1]
+    return None
+
+
+def _load_tf_key_by_function_name_from_lambda_tf(repo_stack_dir: Path) -> dict[str, str]:
+    """
+    Loads mapping of (Lambda function name -> for_each key) from stack/lambda.tf locals.
+
+    Expected shape:
+      locals {
+        lambda_functions = {
+          some_key = {
+            name = "someFunctionName"
+            handler = "..."
+          }
+        }
+      }
+    """
+    lambda_tf = repo_stack_dir / "lambda.tf"
+    if not lambda_tf.exists():
+        return {}
+
+    text = lambda_tf.read_text(encoding="utf-8", errors="ignore")
+    m = re.search(r"(?m)^\s*lambda_functions\s*=\s*\{", text)
+    if not m:
+        return {}
+
+    open_brace_index = m.end() - 1
+    block = _extract_brace_block(text, open_brace_index)
+    if not block:
+        return {}
+
+    tf_key_by_function_name: dict[str, str] = {}
+    entry_start_re = re.compile(r"(?m)^\s*([A-Za-z0-9_]+)\s*=\s*\{")
+    name_re = re.compile(r'(?m)^\s*name\s*=\s*"([^"]+)"\s*,?\s*$')
+
+    for m_entry in entry_start_re.finditer(block):
+        tf_key = m_entry.group(1)
+        open_index = m_entry.end() - 1  # points at "{"
+        entry_block = _extract_brace_block(block, open_index)
+        if not entry_block:
+            continue
+
+        m_name = name_re.search(entry_block)
+        if not m_name:
+            continue
+
+        function_name = m_name.group(1)
+        tf_key_by_function_name.setdefault(function_name, tf_key)
+
+    return tf_key_by_function_name
+
+
 def _terraform_state_has(addr: str) -> bool:
     cp = _run(["terraform", "state", "show", addr])
     return cp.returncode == 0
+
+
+def _aws_list_function_names() -> list[str]:
+    cp = _run(
+        [
+            "aws",
+            "lambda",
+            "list-functions",
+            "--no-paginate",
+            "--query",
+            "Functions[].FunctionName",
+            "--output",
+            "text",
+        ]
+    )
+    if cp.returncode != 0:
+        sys.stderr.write(cp.stdout)
+        sys.stderr.write(cp.stderr)
+        raise SystemExit(cp.returncode)
+
+    return [n for n in cp.stdout.split() if n.strip()]
 
 
 def _aws_alias_exists(function_name: str, alias_name: str) -> bool:
@@ -81,29 +153,43 @@ def main() -> int:
         print("No aws_lambda_alias resource in config; skipping alias import.")
         return 0
 
+    tf_key_by_function_name = _load_tf_key_by_function_name_from_lambda_tf(stack_dir)
+    if not tf_key_by_function_name:
+        sys.stderr.write("Failed to load lambda.tf mapping (locals.lambda_functions.name).\n")
+        return 2
+
+    aws_function_names = _aws_list_function_names()
+
     imported = 0
     skipped_in_state = 0
     skipped_missing_in_aws = 0
+    skipped_not_managed_by_tf = 0
 
-    for tf_key, fn_name in FUNCTIONS:
+    for function_name in aws_function_names:
+        tf_key = tf_key_by_function_name.get(function_name)
+        if not tf_key:
+            skipped_not_managed_by_tf += 1
+            continue
+
         addr = f'aws_lambda_alias.{TERRAFORM_ALIAS_RESOURCE_NAME}["{tf_key}"]'
         if _terraform_state_has(addr):
             skipped_in_state += 1
             continue
 
-        if not _aws_alias_exists(fn_name, LAMBDA_ALIAS_NAME):
+        if not _aws_alias_exists(function_name, LAMBDA_ALIAS_NAME):
             skipped_missing_in_aws += 1
             continue
 
-        print(f'Importing {addr} <- {fn_name}/{LAMBDA_ALIAS_NAME}')
-        _terraform_import(addr, f"{fn_name}/{LAMBDA_ALIAS_NAME}")
+        print(f'Importing {addr} <- {function_name}/{LAMBDA_ALIAS_NAME}')
+        _terraform_import(addr, f"{function_name}/{LAMBDA_ALIAS_NAME}")
         imported += 1
 
     print(
         "Alias import summary: "
         f"imported={imported}, "
         f"already_in_state={skipped_in_state}, "
-        f"missing_in_aws={skipped_missing_in_aws}"
+        f"missing_in_aws={skipped_missing_in_aws}, "
+        f"not_managed_by_tf={skipped_not_managed_by_tf}"
     )
     return 0
 


### PR DESCRIPTION
- Import the 'live' alias so it becomes managed by Terraform
- Publish a new version during Terraform apply so that new changes serve traffic immediately (as opposed to waiting for the code change to take place)

Potentially we can remove this step from the deployment process once all accounts have imported the alias into Terraform.